### PR TITLE
Fixing coverage reported

### DIFF
--- a/lib/karma.phantomjs.coverage.conf.js
+++ b/lib/karma.phantomjs.coverage.conf.js
@@ -45,6 +45,7 @@ module.exports = function conf(config) {
       enforce: 'post',
       test: /\.(j|t)sx?$/,
       include: /src\//,
+      exclude: /node_modules\//,
       use: {
         loader: require.resolve('istanbul-instrumenter-loader'),
         options: { esModules: true },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-test",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "description": "test tools for react component",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-test",
-  "version": "6.0.9",
+  "version": "6.0.8",
   "description": "test tools for react component",
   "keywords": [
     "react",


### PR DESCRIPTION
Fixing coverage reported in input-number [https://github.com/react-component/input-number] after a commit of mine

- node_modules/src/** was included (Match /src\// Regex) into the coverage report which made the coverage not correct

Example of affecting input-number:

![fake_coverage](https://user-images.githubusercontent.com/7091543/34165575-4fcf5e92-e4e5-11e7-9d8b-39b203f8cc35.png)

After the fix:

![fixed](https://user-images.githubusercontent.com/7091543/34165594-608ae51c-e4e5-11e7-80f1-df2a660538b4.png)
