### PR TITLE
chore: add npm test ver

### DIFF
--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,0 +1,19 @@
+name: react component workflow
+
+on: [workflow_call]
+
+jobs:
+  react-component-workflow:
+    name: react component workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: npm i --legacy-peer-deps
+      - run: npm run lint
+      - run: npx tsc --noEmit
+      - run: npm run compile
+      - run: npm run test -- --coverage
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
       - run: npm i --legacy-peer-deps
       - run: npm run lint
       - run: npx tsc --noEmit


### PR DESCRIPTION
bun 在多版本下，会错误提升 React 版本。加个 npm 纯血版测试：

<img width="789" alt="截屏2024-12-06 17 37 56" src="https://github.com/user-attachments/assets/1fa110ac-8634-4e43-9919-8898d8eef71a">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的 GitHub Actions 工作流 `test-npm.yml`，用于测试 React 组件。
	- 该工作流自动执行代码检查、类型检查、编译和测试，确保代码质量和覆盖率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->