### PR TITLE
refactor: lock bun to 1.1.12 for unexpected peer deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.1.12
       - run: bun i
       - run: bun run lint
       - run: bunx tsc --noEmit


### PR DESCRIPTION
锁定 bun 的版本为 1.1.12 以绕过非预期 peer dependencies 解析导致 father 构建失败的问题，等 bun 修复后再解除锁定：

![图片](https://github.com/user-attachments/assets/ce235c95-5417-44aa-affc-f6e6fc6784f4)
现场链接：https://github.com/react-component/motion/actions/runs/13254919898/job/37000056389?pr=62

关联 father PR：https://github.com/umijs/father/pull/804
关联 bun issue：https://github.com/oven-sh/bun/issues/8406#issuecomment-2650177369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 更新了自动化流程配置，确保所有构建和测试任务使用 Bun 版本 1.1.12，从而提升整体环境一致性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->