### PR TITLE
chore: upgrade test-utoo workflow maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+      interval: weekly
+      day: monday
+      time: "21:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: "21:00"
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 10

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,13 +1,19 @@
 name: react component workflow
 
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   react-component-workflow:
     name: react component workflow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - run: npm i --legacy-peer-deps
       - run: npm run lint
       - run: npx tsc --noEmit

--- a/.github/workflows/test-utoo.yml
+++ b/.github/workflows/test-utoo.yml
@@ -1,16 +1,22 @@
 name: react component workflow
 
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   react-component-workflow:
     name: react component workflow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: utooland/setup-utoo@v1
         with:
-          utoo-version: 'latest'
+          utoo-version: "latest"
           cache-store: true
       - run: ut
       - run: ut lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,19 @@
 name: react component workflow
 
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   react-component-workflow:
     name: react component workflow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@v2
       - run: bun i
       - run: bun run lint


### PR DESCRIPTION
## Summary

- Upgrade the reusable `test-utoo.yml` workflow to `actions/checkout@v7`.
- Align `test.yml` and `test-npm.yml` with the same reusable workflow contract: `actions/checkout@v7`, `persist-credentials: false`, and optional `CODECOV_TOKEN` declarations.
- Standardize Dependabot scheduling for npm and GitHub Actions updates.
- Keep the existing npm/bun/utoo lint/type/compile/test/codecov flows unchanged.

This is part of the rc component standardization tracked in ant-design/ant-design#58514. Declaring `CODECOV_TOKEN` in the reusable workflows lets downstream rc component repositories switch from broad `secrets: inherit` to explicit secret forwarding in follow-up PRs after these workflows land on `main`.

## Test

- `npx --yes prettier@3.6.2 --check .github/workflows/test-utoo.yml .github/workflows/test-npm.yml .github/workflows/test.yml .github/dependabot.yml`
- YAML parse check for `test-utoo.yml`, `test-npm.yml`, and `test.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 更新了自动化工作流配置，增强了调用时的密钥声明支持，并升级了检出步骤配置，提升持续集成稳定性。
  * 调整了依赖更新机器人设置，改为固定每周更新时间，并限制同时打开的更新请求数量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->