### PR TITLE
ci: add reusable Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy documentation to GitHub Pages
+
+on:
+  workflow_call:
+    inputs:
+      build-command:
+        description: Command used to build documentation
+        required: false
+        type: string
+        default: ut run build
+      publish-dir:
+        description: Directory containing the built documentation
+        required: false
+        type: string
+        default: docs-dist
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: utooland/setup-utoo@v1
+        with:
+          utoo-version: latest
+          registry: https://registry.npmjs.org/
+          cache-store: true
+      - run: ut
+      - name: Build documentation
+        run: ${{ inputs.build-command }}
+        env:
+          GH_PAGES: '1'
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ${{ inputs.publish-dir }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- add a reusable workflow for building rc documentation with utoo
- deploy the generated artifact through GitHub Pages
- allow callers to override the build command and publish directory

## Verification

- YAML syntax validation
- `git diff --check`